### PR TITLE
fix: handle base64 padding and use urlsafe decoding for authentication token payload

### DIFF
--- a/lkr/load_test/utils.py
+++ b/lkr/load_test/utils.py
@@ -106,7 +106,8 @@ def extract_looker_user_id_from_token(
         return None
     try:
         payload = response.authentication_token.split(".")[1]
-        payload_bytes = base64.b64decode(payload)
+        payload += "=" * ((4 - len(payload) % 4) % 4)
+        payload_bytes = base64.urlsafe_b64decode(payload)
         payload_json = json.loads(payload_bytes)
         credentials = json.loads(payload_json.get("credentials"))
         if not credentials:


### PR DESCRIPTION
When running headless load tests (such as lkr load-test query), the tool uses Cookieless Embedding to acquire a session token for simulated users via acquire_embed_cookieless_session. It then parses the returned JWT authentication_token to extract the Looker User ID in order to impersonate that user for subsequent REST API calls.

However, the JWT token payload is base64url-encoded and typically lacks trailing padding characters (=). Because lkr/load_test/utils.py attempted to decode this raw payload using standard base64.b64decode, it would consistently fail.

PR updates the token extraction logic in lkr/load_test/utils.py to:
Dynamically calculate and append the correct number of padding characters (=) to make the base64 string length a multiple of 4.
Switched from standard base64.b64decode to base64.urlsafe_b64decode to correctly and safely decode base64url JWT payloads.