### PR TITLE
fix: resolve container permission denied error under non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ COPY lkr ./lkr
 ENV SE_OFFLINE=true
 ENV SE_AVOID_STATS=true
 ENV UV_PROJECT_ENVIRONMENT="/usr/local/"
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-editable
 
 # Create a non-root user and switch to it
-RUN useradd -m --no-log-init appuser
+RUN useradd -m --no-log-init appuser && \
+    chown -R appuser:appuser /app
 USER appuser
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN uv sync --frozen --no-dev --no-editable
 
 # Create a non-root user and switch to it
 RUN useradd -m --no-log-init appuser && \
-    chown -R appuser:appuser /app
+    chown appuser:appuser /app
 USER appuser
 


### PR DESCRIPTION
This PR fixes Issue #27.

Changes:
1. Installs the project as a non-editable package under python site-packages by passing the `--no-editable` flag to `uv sync`.
2. Changes ownership of the `/app` directory to `appuser` to grant the non-root user write access to the working directory.

Fixed #27