### PR TITLE
feat: add --cache-percent option to query load test

### DIFF
--- a/lkr.md
+++ b/lkr.md
@@ -144,7 +144,7 @@ $ lkr load-test query [OPTIONS]
 * `--async-bail-out INTEGER`: How many iterations to wait for the async query to complete (roughly number of seconds)  [default: 120]
 * `--first-name TEXT`: First name of the embed user  [default: Embed]
 * `--max-queries-per-task INTEGER RANGE`: Maximum number of unique queries to execute per task iteration  [default: 1; x&gt;=1]
-* `--cache-percent FLOAT RANGE`: Percentage of queries to run with cache enabled (0.0 to 1.0 or 0 to 100)  [default: 0.0; 0.0&lt;=x&lt;=100.0]
+* `--cache-percent FLOAT RANGE`: Percentage of queries to run with cache enabled (0 to 100)  [default: 0.0; 0.0&lt;=x&lt;=100.0]
 * `--help`: Show this message and exit.
 
 ### `lkr load-test dashboard-queries`

--- a/lkr.md
+++ b/lkr.md
@@ -144,6 +144,7 @@ $ lkr load-test query [OPTIONS]
 * `--async-bail-out INTEGER`: How many iterations to wait for the async query to complete (roughly number of seconds)  [default: 120]
 * `--first-name TEXT`: First name of the embed user  [default: Embed]
 * `--max-queries-per-task INTEGER RANGE`: Maximum number of unique queries to execute per task iteration  [default: 1; x&gt;=1]
+* `--cache-percent FLOAT RANGE`: Percentage of queries to run with cache enabled (0.0 to 1.0 or 0 to 100)  [default: 0.0; 0.0&lt;=x&lt;=100.0]
 * `--help`: Show this message and exit.
 
 ### `lkr load-test dashboard-queries`

--- a/lkr/load_test/locustfile_qid.py
+++ b/lkr/load_test/locustfile_qid.py
@@ -102,12 +102,7 @@ class QueryUser(User):
         self.cache_percent: float = 0.0
 
     def _should_use_cache(self) -> bool:
-        # accepts 0.0-1.0 probability or 0-100 percentage
-        prob = (
-            self.cache_percent / 100.0
-            if self.cache_percent > 1.0
-            else self.cache_percent
-        )
+        prob = self.cache_percent / 100.0
         return random.random() < prob if prob > 0 else False
 
     def _init_sdk(self):

--- a/lkr/load_test/locustfile_qid.py
+++ b/lkr/load_test/locustfile_qid.py
@@ -99,6 +99,16 @@ class QueryUser(User):
         self.group_ids: List[str] = []
         self.external_group_id: str | None = None
         self.first_name: str = "Embed"
+        self.cache_percent: float = 0.0
+
+    def _should_use_cache(self) -> bool:
+        # accepts 0.0-1.0 probability or 0-100 percentage
+        prob = (
+            self.cache_percent / 100.0
+            if self.cache_percent > 1.0
+            else self.cache_percent
+        )
+        return random.random() < prob if prob > 0 else False
 
     def _init_sdk(self):
         sdk = looker_sdk.init40()
@@ -189,7 +199,7 @@ class QueryUser(User):
                             query_id=query_obj.id,
                             result_format=result_format,
                         ),
-                        cache=False,
+                        cache=self._should_use_cache(),
                     )
                     if not ts.task:
                         ts.task = datetime.datetime.now()
@@ -249,7 +259,9 @@ class QueryUser(User):
                             self.queries[q] = sdk.query_for_slug(q)
                     query_obj = self.queries.get(q)
                     qid = str(query_obj.id) if query_obj and query_obj.id else q
-                    res = sdk.run_query(qid, result_format=self.result_format, cache=False)
+                    res = sdk.run_query(
+                        qid, result_format=self.result_format, cache=self._should_use_cache()
+                    )
                     self.environment.events.request.fire(request_type="run_query", name="run_query_sync", response_time=(time.time() - start_time) * 1000, response_length=len(str(res)))
                 except Exception as e:
                     self.environment.events.request.fire(request_type="run_query", name="run_query_sync", response_time=(time.time() - start_time) * 1000, response_length=0, exception=e)

--- a/lkr/load_test/test_utils.py
+++ b/lkr/load_test/test_utils.py
@@ -254,12 +254,9 @@ def test_query_user_should_use_cache(monkeypatch):
     assert user._should_use_cache() is True
 
     user.cache_percent = 1.0
+    monkeypatch.setattr("random.random", lambda: 0.009)
     assert user._should_use_cache() is True
-
-    user.cache_percent = 0.5
-    monkeypatch.setattr("random.random", lambda: 0.49)
-    assert user._should_use_cache() is True
-    monkeypatch.setattr("random.random", lambda: 0.51)
+    monkeypatch.setattr("random.random", lambda: 0.011)
     assert user._should_use_cache() is False
 
     user.cache_percent = 50.0

--- a/lkr/load_test/test_utils.py
+++ b/lkr/load_test/test_utils.py
@@ -180,12 +180,55 @@ def test_get_system_activity_explore_url_with_query_ids(monkeypatch):
     assert query_params["f[query.slug]"] == ["qid1,qid2"]
 
     filter_config = json.loads(query_params["filter_config"][0])
-    assert "query.slug" in filter_config
+    assert filter_config["query.slug"]
     filters = filter_config["query.slug"]
     assert len(filters) == 1
     assert filters[0]["type"] == "="
     assert filters[0]["id"] == 2
     assert filters[0]["values"][0]["constant"] == "qid1,qid2"
+
+
+def test_get_system_activity_explore_url_with_cache_metrics(monkeypatch):
+    monkeypatch.setenv("LOOKERSDK_BASE_URL", "https://myinstance.looker.com")
+
+    from urllib.parse import urlparse, parse_qs
+    import json
+
+    url = get_system_activity_explore_url(
+        5, query_ids=["qid1", "qid2"], include_cache_metrics=True
+    )
+    assert url is not None
+
+    parsed = urlparse(url)
+    query_params = parse_qs(parsed.query)
+
+    fields = query_params["fields"][0].split(",")
+    assert "history.created_minute" in fields
+    assert "history.query_run_count" in fields
+    assert "user.count" in fields
+    assert "history.cache_result_query_count" in fields
+    assert "history.database_result_query_count" in fields
+    assert "query.slug" in fields
+
+    assert "vis" in query_params
+    vis = json.loads(query_params["vis"][0])
+    assert vis["table_theme"] == "modern"
+    assert vis["modern2026"] is True
+    assert vis["hidden_fields"] == [
+        "history.cache_result_query_count",
+        "history.database_result_query_count",
+    ]
+
+    assert "dynamic_fields" in query_params
+    dynamic_fields = json.loads(query_params["dynamic_fields"][0])
+    assert len(dynamic_fields) == 1
+    assert dynamic_fields[0]["category"] == "table_calculation"
+    assert (
+        dynamic_fields[0]["expression"]
+        == "${history.cache_result_query_count} / (${history.cache_result_query_count} + ${history.database_result_query_count})"
+    )
+    assert dynamic_fields[0]["label"] == "Cache Hit Rate"
+    assert dynamic_fields[0]["table_calculation"] == "cache_hit_rate"
 
 
 def test_safe_get_ident_fallback():
@@ -197,6 +240,34 @@ def test_safe_get_ident_fallback():
     ident = _safe_get_ident()
     assert isinstance(ident, int)
     assert threading.get_ident() == ident
+
+
+def test_query_user_should_use_cache(monkeypatch):
+    from lkr.load_test.locustfile_qid import QueryUser
+
+    user = QueryUser.__new__(QueryUser)
+
+    user.cache_percent = 0.0
+    assert user._should_use_cache() is False
+
+    user.cache_percent = 100.0
+    assert user._should_use_cache() is True
+
+    user.cache_percent = 1.0
+    assert user._should_use_cache() is True
+
+    user.cache_percent = 0.5
+    monkeypatch.setattr("random.random", lambda: 0.49)
+    assert user._should_use_cache() is True
+    monkeypatch.setattr("random.random", lambda: 0.51)
+    assert user._should_use_cache() is False
+
+    user.cache_percent = 50.0
+    monkeypatch.setattr("random.random", lambda: 0.49)
+    assert user._should_use_cache() is True
+    monkeypatch.setattr("random.random", lambda: 0.51)
+    assert user._should_use_cache() is False
+
 
 
 

--- a/lkr/load_test/utils.py
+++ b/lkr/load_test/utils.py
@@ -123,6 +123,7 @@ def get_system_activity_explore_url(
     run_time_minutes: int,
     dashboard_ids: List[str] | None = None,
     query_ids: List[str] | None = None,
+    include_cache_metrics: bool = False,
 ) -> str | None:
     if dashboard_ids is None:
         dashboard_ids = []
@@ -158,16 +159,24 @@ def get_system_activity_explore_url(
         ]
     }
 
-    fields_str = "history.created_minute,history.query_run_count,user.count"
+    fields_list = ["history.created_minute", "history.query_run_count", "user.count"]
+    if include_cache_metrics:
+        fields_list.extend([
+            "history.cache_result_query_count",
+            "history.database_result_query_count",
+        ])
+
     pivots_str = None
     filter_id = 2
 
     if len(dashboard_ids) > 1:
-        fields_str += ",dashboard.title"
+        fields_list.append("dashboard.title")
         pivots_str = "dashboard.title"
     elif len(query_ids) > 1:
-        fields_str += ",query.slug"
+        fields_list.append("query.slug")
         pivots_str = "query.slug"
+
+    fields_str = ",".join(fields_list)
 
     query_params = {
         "fields": fields_str,
@@ -180,6 +189,34 @@ def get_system_activity_explore_url(
 
     if pivots_str is not None:
         query_params["pivots"] = pivots_str
+
+    if include_cache_metrics:
+        query_params["vis"] = json.dumps(
+            {
+                "table_theme": "modern",
+                "modern2026": True,
+                "hidden_fields": [
+                    "history.cache_result_query_count",
+                    "history.database_result_query_count",
+                ],
+            },
+            separators=(",", ":"),
+        )
+        query_params["dynamic_fields"] = json.dumps(
+            [
+                {
+                    "category": "table_calculation",
+                    "expression": "${history.cache_result_query_count} / (${history.cache_result_query_count} + ${history.database_result_query_count})",
+                    "label": "Cache Hit Rate",
+                    "value_format": None,
+                    "value_format_name": "percent_2",
+                    "_kind_hint": "measure",
+                    "table_calculation": "cache_hit_rate",
+                    "_type_hint": "number",
+                }
+            ],
+            separators=(",", ":"),
+        )
 
     if dashboard_ids:
         dashboards_str = ",".join(dashboard_ids)

--- a/lkr/main.py
+++ b/lkr/main.py
@@ -546,7 +546,7 @@ def load_test_query(
     cache_percent: Annotated[
         float,
         typer.Option(
-            help="Percentage of queries to run with cache enabled (0.0 to 1.0 or 0 to 100)",
+            help="Percentage of queries to run with cache enabled (0 to 100)",
             min=0.0,
             max=100.0,
         ),

--- a/lkr/main.py
+++ b/lkr/main.py
@@ -543,6 +543,14 @@ def load_test_query(
             min=1,
         ),
     ] = 1,
+    cache_percent: Annotated[
+        float,
+        typer.Option(
+            help="Percentage of queries to run with cache enabled (0.0 to 1.0 or 0 to 100)",
+            min=0.0,
+            max=100.0,
+        ),
+    ] = 0.0,
 ):
     """
     Run a load test by executing specific queries by ID.
@@ -579,7 +587,11 @@ def load_test_query(
     typer.echo(
         f"Running load test with {users} users, {spawn_rate} spawn rate, and {run_time} minutes"
     )
-    explore_url = get_system_activity_explore_url(run_time, query_ids=resolved_queries)
+    explore_url = get_system_activity_explore_url(
+        run_time,
+        query_ids=resolved_queries,
+        include_cache_metrics=cache_percent > 0,
+    )
     if explore_url:
         typer.echo(f"\nTrack query history for the load test here:\n{explore_url}\n")
 
@@ -604,6 +616,7 @@ def load_test_query(
             )
             self.max_queries_per_task = max_queries_per_task
             self.first_name = first_name
+            self.cache_percent = cache_percent
 
     from locust import events
     from locust.env import Environment


### PR DESCRIPTION
## Description
- Adds `--cache-percent` (float, range `[0.0, 100.0]`) to the `lkr load-test query` command to randomize Looker query cache usage.
- Updates `QueryUser` in `locustfile_qid.py` to randomly pass `cache=True` or `cache=False` based on `cache_percent`.
- Updates `get_system_activity_explore_url` to include `history.cache_result_query_count`, `history.database_result_query_count`, and a `Cache Hit Rate` table calculation with hidden count fields when cache is enabled (`cache_percent > 0`).
- Adds unit tests for cache probability evaluation and Explore URL generation with cache metrics.

Fixes #29